### PR TITLE
New syntax

### DIFF
--- a/D2547.md
+++ b/D2547.md
@@ -1555,7 +1555,7 @@ assert(get_first(t) == 42);
 assert(get_float(t) == 1.0f);
 ```
 
-Note that the template arguments of `std::get` are never deduced, which is why we can allow multiple CPOs of the same name to coexist.
+Note that the template arguments of `std::get` are never deduced, they must always be explicitly provided by the caller.
 
 A type can define non-template customisations of template customisable functions as follows:
 

--- a/D2547.md
+++ b/D2547.md
@@ -1647,18 +1647,27 @@ struct allocator_receiver {
 
 In a function-call expression, if the _postfix-expression_ operand of the call expression denotes a Customizable Function Object, then overload resolution is performed as follows:
 
- - Let `F` be the decayed type of the customisable function object `O` and `args...` be the sequence of argument expressions for the call expression
- - Start with an empty set of customisation overloads
- - For each associated entity of arguments passed to the call-expression look in each of the associated namespaces for
-   - non-member functions marked with `override` where either;
+ - Let:
+   - `O` be the customisable function object in the _postfix-expression_ operand position
+   - `F` be the decayed type of the customisable function object, `O`,
+   - `args...` be the sequence of argument expressions for the call expression
+ - Let the set, `Ef`, contain the associated entites of the type `F`
+   - This includes the associated entities of any explicit type template parameters of a generic CFO
+ - Let the set, `Ea`, contain the associated entities of each of the argument types in `args...`
+ - If the customisable function object has any associated function declarations marked `customisable` then let `E` be the union of `Ef` and `Ea`
+ - Otherwise, let `E` be `Ef`
+ - Let the _customisation overload set_ be initially the empty set.
+ - For each associated entity, `e`, in `E` look in its associated namespaces of `e` for
+   - non-member functions marked with `override` or `final` where either;
      - the declarator-id names an object that has type `F`; or
      - the declarator-id is a dependent name deducible to `O`
-   - if the override is a function template then attempt to deduce the template arguments based on the types of the argument expressions in the postfix call expression.
-     - if template argument deduction fails the discard this override
-   - if any of the constraints of the override declaration are not met then discard this override.
-   Add each overload found to the _customisation overload set_.
+   - if the overload is a function template then attempt to deduce the template arguments based on the types of the argument expressions in the postfix call expression.
+     - if template argument deduction fails then discard this overload
+   - if any of the constraints of the overload declaration are not met then discard this overload.
+   - otherwise, if the overload was not discarded, add it to the _customisation overload set_.
  - form an argument list `(args...)` and attempt to perform overload resolution using this argument list on the overloads in the _customisation overload set_.
  - if overload resolution finds a single, best overload then call-expression resolves to a call to this overload
+   - if any of the candidate overloads in the _customisation overload set_ are marked `final` then there must be exactly one such overload and it must be the selected overload (otherwise this indicates that someone has declared an override for a function marked `final`)
  - otherwise, if there were viable candidates; then the call-expression is ill-formed
    [[Note: Because the call is ambiguous]]
  - otherwise, if there were no viable candidates in the overload set, perform a second overload resolution with the same argument list, this time on the set of function definitions marked marked with `default` (which are found in the customisable function’s private associated namespace).
@@ -1713,6 +1722,9 @@ This is done by attempting to match the signature of the selected overload to th
  - If there were no customisable function prototypes that were not discarded for which the overload was able to successfully match then the program is ill-formed. [[Note: Because the implementation was an invalid overload]].
 
 Parts of this process are described in more detail [Noexcept specifications](#noexcept-specifications), [Constraining parameter-types](#constraining-parameter-types) and [Constraining return types](#constraining-return types).
+
+The above checks are not performed if the selected overload was declared `final` and in the same namespace as the CFO being invoked.
+Such overloads are not considered to be implmentations of a customisable function prototype but instead are independent function overloads.
 
 ### Noexcept specifications
 

--- a/D2547.md
+++ b/D2547.md
@@ -1593,7 +1593,7 @@ struct array {
 };
 ```
 
-# Generic forwarding
+## Generic forwarding
 
 When we are building wrapper types we want to be able to forward through a set of customisable function calls on the wrapper to the wrapped object.
 

--- a/D2547.md
+++ b/D2547.md
@@ -51,7 +51,7 @@ The proposed syntax introduces use of:
   - The `default`{.cpp} keyword as an additional _virt-specifier_ annotation for a customisable function’s default implementation.
   - The _virt-specifier_ `final`{.cpp} to create a non-customisable function object.
   - A syntax for declaring customisations of a specific customisable function-object by using the fully-scoped name of the function-object as the function-name.
-  - The ability to deduce the customisable function object for the purposes of generic forwarding.
+  - The ability to deduce the customisable function object for the purposes of generic forwarding and generically customising multiple customisation-points.
 
 # Terminology
 

--- a/D2547.md
+++ b/D2547.md
@@ -35,7 +35,7 @@ We need directional guidance from EWG and LEWG to refine the design over the nex
 This proposal seeks to improve over existing customisation point mechanisms in a number of ways:
 
   - Allows customisation-point names to be namespace-scoped rather than names being reserved globally.
-  - Allows generic forwarding of customisable functions through wrapper-types, including generic type-erasing wrappers (like `std::optional`) and adapters that customise some operations and pass through others.
+  - Allows generic forwarding of customisable functions through wrapper-types, including generic type-erasing wrappers (like `unifex::any_object`) and adapters that customise some operations and pass through others.
   - Concise syntax for defining customisable function-objects and adding customisations for particular types.
   - Support for copy-elision of arguments passed by-value to customisation points.
   - Far better compile times compared to the `tag_invoke` mechanism (avoids 3 layers of template instantiations and cuts down on SFINAE required to separate implementation functions)

--- a/D2547.md
+++ b/D2547.md
@@ -106,11 +106,11 @@ namespace std::execution {
 namespace std::ranges {
   template<input_range R, typename Value>
     requires equality_comparable_with<range_reference_t<R>, Value>
-  bool contains(R range, Value v) customisable;
+  bool contains(R range, Value v) @[customisable]{.hl}@;
 
   template<input_range R, typename Value>
     requires equality_comparable_with<range_reference_t<R>, Value>
-  bool contains(R&& range, const Value& v) default {
+  bool contains(R&& range, const Value& v) @[default]{.hl}@ {
     for (const auto& x : range) {
       if (x == v) return true;
     }
@@ -234,7 +234,7 @@ namespace std {
 	}
   auto @[get]{.hl}@(Obj&& obj, std::integral_constant<size_t, N>) final {
     -> decltype(auto) {
-       return get<N>(std::forward<Obj>(obj)};
+       return get<N>(std::forward<Obj>(obj));
   }
 }
 

--- a/D2547.md
+++ b/D2547.md
@@ -220,14 +220,15 @@ namespace std {
   template<size_t N, typename Obj>
   auto @[get<N>]{.hl}@(Obj&& obj) customisable;
 
-  // get that deduces numeric indices, no template args
+  // non-template get() that deduces numeric indices
+  // callable without explicit template args
   template<size_t N, typename Obj>
-  auto @[get]{.hl}@(Obj&& obj, std::integral_constant<size_t, N>) customisable;
-
-  template<size_t N, typename Obj>
-  auto @[get]{.hl}@(Obj&& obj, std::integral_constant<size_t, N>) default
+    requires (Obj&& obj) {
+	  get<N>(std::forward<Obj>(obj));
+	}
+  auto @[get]{.hl}@(Obj&& obj, std::integral_constant<size_t, N>) final {
     -> decltype(auto) {
-       return std::get<N>(std::forward<Obj>(obj);
+       return get<N>(std::forward<Obj>(obj)};
   }
 }
 

--- a/D2547.md
+++ b/D2547.md
@@ -26,10 +26,16 @@ We intend this proposal to replace the use of `tag_invoke` in [@P2300R5] in the 
 We need directional guidance from EWG and LEWG to refine the design over the next few months.
 
 ## Revision 1
-  - New syntax to introduce customisable functions, using a contextual keyword (`customisable`)
-  rather than `virtual`. This is to address initial feedback that re-using `virtual` for a feature
-  unrelated to dynamic polymorphism was, at best, confusing.
+  - New syntax to introduce customisable functions, using a contextual keyword, `customisable`, rather than `virtual` and `= 0`.
+    This is to address initial feedback that re-using `virtual` for a feature unrelated to dynamic polymorphism was, at best, confusing.
+  - Default implementations can no longer be defined together with the declaration of the customisable function prototype.
+    The treatment of a function parameters and template argument deduction between the two is different enough that it was thought to be confusing to allow them to be the same declaration.
   - Add support for the `final` keyword to annotate a function that may not be overridden.
+  - Change overload resolution of customisable functions so it always considers the associated entities/namespaces of the CFO itself.
+    This allows generic overrides (that customise for a whole concept instead of a particular type) to be defined in a place it is guaranteed to be found.
+    It also allows overloads for a template customisable function to be found in namespaces of the explicit type template arguments to the CFO.
+  - Add more examples of template customisable functions and generic customisations.
+  - Improve terminology consistency - use "customisable functions" and CFOs (customisable function objects) instead of CPOs (customisation-point objects)
 
 # Short description of the proposed facilities
 

--- a/D2547.md
+++ b/D2547.md
@@ -244,12 +244,84 @@ struct my_tuple {
 };
 ```
 
+A customisable function template can also be customised generically by providing a template
+parameter as the template argument to the customisable function's template argument:
+```cpp
+template<typename T, std::size_t N>
+struct array {
+  T data[N];
+  
+  // Use a function-template parameter to deduce the CFO parameter
+  template<std::size_t Idx>
+    requires (Idx < N)
+  friend T& std::get<Idx>(array& self) noexcept override { return self.data[Idx]; }
+};
+
+template<typename First, typename Second>
+struct pair {
+  First first;
+  Second second;
+  
+  // Use a class-template parameter to constrain the CFO parameter
+  friend First& std::get<First>(pair& self) noexcept override
+	    requires (!std::same_as<First, Second>) {
+	  return self.first;
+  }
+
+  // ...
+};
+```
+
+Usage of this customisable function template works as follows:
+```cpp
+void example() {
+  my_tuple t = {42, 0.0f};
+  
+  int& x1 = std::get<0>(t);
+  float& y1 = std::get<1>(t);
+
+  int& x2 = std::get<int>(t);
+  float& y2 = std::get<float>(t);
+  
+  int& x3 = std::get(t, std::integral_constant<std::size_t, 0>{});
+  float& y3 = std::get(t, std::integral_constant<std::size_t, 1>{});
+}
+```
+
 _Note:_ unlike variables and variable templates, CFOs are not less-than-comparable, which means `cfo-name<token>` can be unambiguously parsed as a template name and not a comparison, similar to function templates.
 This allows CFOs and CFO-templates to coexist in the same namespace.
 
 ## Generic customisations
 
 A type can customise a set of customisable-functions generically by defining namespace-scope **generic customisation**.
+
+```cpp
+template<typename Inner>
+struct unstoppable_receiver_wrapper {
+  Inner inner;
+
+  // Customise get_stop_token() to return never_stop_token.
+  friend constexpr never_stop_token std::execution::get_stop_token(
+      const unstoppable_receiver_wrapper& self) noexcept override {
+    return {};
+  }
+
+  // Generically customise all other queries to forward them to the wrapped receiver.
+  template<@[auto func]{.hl}@>
+    requires requires(const Inner& inner) { func(inner); }
+  friend constexpr auto @[func]{.hl}@(const unstoppable_receiver_wrapper& self)
+      noexcept(noexcept(func(self.inner))) @[override]{.hl}@
+      -> decltype(func(self.inner)) {
+    return @[func]{.hl}@(self.inner);
+  }
+
+  // ... etc. for forwarding set_value/set_error/set_done customisable functions
+};
+```
+
+This can be made even more generic by accepting a first parameter that accepts an arbitrary
+set of parameters and different value-categories of the first argument:
+
 ```cpp
 template<typename Obj, typename Member>
 using member_t = decltype((std::declval<Obj>().*std::declval<Member std::remove_cvref_t<Obj>::*>()));

--- a/D2547.md
+++ b/D2547.md
@@ -29,6 +29,7 @@ We need directional guidance from EWG and LEWG to refine the design over the nex
   - New syntax to introduce customisable functions, using a contextual keyword (`customisable`)
   rather than `virtual`. This is to address initial feedback that re-using `virtual` for a feature
   unrelated to dynamic polymorphism was, at best, confusing.
+  - Add support for the `final` keyword to annotate a function that may not be overridden.
 
 # Short description of the proposed facilities
 

--- a/D2547.md
+++ b/D2547.md
@@ -39,7 +39,7 @@ This proposal seeks to improve over existing customisation point mechanisms in a
   - Concise syntax for defining customisable function-objects and adding customisations for particular types.
   - Support for copy-elision of arguments passed by-value to customisation points.
   - Far better compile times compared to the `tag_invoke` mechanism (avoids 3 layers of template instantiations and cuts down on SFINAE required to separate implementation functions)
-  - Far better error messages compared to the `tag_invoke` mechanism (`tag_invoke` does not distinguish between different customisation point functions and results in sometimes hundreds of overloads)
+  - Far better error messages compared to the `tag_invoke` mechanism (`tag_invoke` does not distinguish between different customisation point functions and sometimes results in reporting hundreds of unrelated overloads)
 
 This proposal improves on the semantics of the `tag_invoke` proposal [@P1895R0], keeping namespace-scoped customisation points and generic customisation / forwarding, while providing a terser and cleaner syntax accessible to less experienced programmers.
 
@@ -49,7 +49,7 @@ The proposed syntax introduces use of:
   - The _virt-specifier_ `override`{.cpp} for customisations of a customisable function-object.
   - The `default`{.cpp} keyword as an additional _virt-specifier_ annotation for a customisable function’s default implementation.
   - The _virt-specifier_ `final`{.cpp} to create a non-customisable function object.
-  - A syntax for declaring customisations of a specific customisable function-object by using the  fully-scoped name of the function-object as the function-name.
+  - A syntax for declaring customisations of a specific customisable function-object by using the fully-scoped name of the function-object as the function-name.
   - The ability to deduce the customisable function object for the purposes of generic forwarding.
 
 # Terminology
@@ -87,7 +87,7 @@ namespace std::execution {
 }
 ```
 
-## Declaring a customisable function contains that has a default implementation
+## Declaring a customisable function `contains` that has a default implementation
 
 ```cpp
 namespace std::ranges {
@@ -180,7 +180,7 @@ void lookup_example() {
 ```
 
 A customisable function prototype creates a name that identifies an empty object that can be passed around by value.
-This object represents the overload set of all overloads of that function, and so can be passed to higher-order functions without having to wrap it in a lambda.
+This object represents the overload set of all overloads of that customisable function, and so can be passed to higher-order functions without having to wrap it in a lambda.
 
 ```cpp
 template<typename T>
@@ -317,7 +317,7 @@ While the `tag_invoke` mechanism for implementing customisation points is functi
   - Every customisation uses the name `tag_invoke`, which can make for a large overload-set that the compiler has to consider.
     Types that customise a large number of CPOs have all of those customisations added to the overload-set for every call to a CPO with that type as an argument.
     This can impact compile times when used at scale, and heavily impacts user-visible error messages.
-  - The `tag_invoke` forwarding mechanism requires a lot of template instantiations when instantiating the call operator (`tag_invocable` concept for constraint, `tag_invoke_result_t` for return type, `is_nothrow_tag_invocable_v` to forward `noexcept` clause, the `std::tag_invoke_t::operator()` template function.
+  - The `tag_invoke` forwarding mechanism requires a lot of template instantiations when instantiating the call operator (`tag_invocable` concept for constraint, `tag_invoke_result_t` for return type, `is_nothrow_tag_invocable_v` to forward `noexcept` clause, the `std::tag_invoke_t::operator()` function template.
     This can potentially impact compile-time in code where there are a large number of calls to CPOs.
 
 For example, defining a hypothetical `std::ranges::contains` customisable function with a default implementation requires a lot of boiler-plate with `tag_invoke`.
@@ -376,7 +376,6 @@ bool contains(R&& range, const Value& v) default {
   return false;
 }
 
-
 } // namespace std::ranges
 ```
 
@@ -416,7 +415,7 @@ While [@P2279R0] does a great job of surveying the existing techniques used for 
 
 * (from the perspective of generic programming)
 
-If a generic concept defined by one library wants to use the `foo()` member function name as a customisation point, it will potentially conflict with _another_ library that also uses the `foo()` member function name as a customisation point with different implied semantics.
+If a generic concept defined by one library wants to use the `.foo()` member function name as a customisation point, it will potentially conflict with _another_ library that also uses the `.foo()` member function name as a customisation point with different implied semantics.
 
 This can lead to types accidentally satisfying a given concept syntactically even if the semantics of the implementations don’t match because they are implementing a different concept.
 
@@ -1863,8 +1862,8 @@ a form of static polymorphism.
 
 However, it is clear from the initial reactions, that most people associate `virtual`
 with inheritence and dynamic polymorphism.
-As this proposal is definitively not that(It is a compile0time mechanism
-which does not impact runtime performance), R1 introduce a different syntax.
+As this proposal is definitively not that (it is a compile-time mechanism
+which does not impact runtime performance), R1 introduced a different syntax.
 
 Some additional concerns were raised that `virtual` may also be used by multimethods,
 should such a proposal ever be made and be accepted.
@@ -1897,7 +1896,7 @@ The current argument dependent lookup rules can often result in the compiler sea
 It would be great if we had better control over which set of associated namespaces the compiler considers when performing argument-dependent lookup.
 
 There are two main features that could be considered as companions to this paper:
- - Declaring that certain parameters of a customisable function should not be considered when constructing the list of associated namespaces (this builds on top of this paper)
+ - Declaring that certain parameters of a customisable function should not be considered when constructing the list of associated namespaces (this can build on top of this paper)
  - Declaring that certain template parameters of a class template should not be considered when constructing the list of associated namespaces (this is discussed in [@P2256R0]).
 
 ## Comparison to Rust Traits
@@ -1926,7 +1925,6 @@ template<typename T>
 requires requires(const T& x, const T& y) {
     eq(x, y);
 }
-
 bool ne(const T& x, const T& y) customisable;
 
 bool ne(const T& x, const T& y) noexcept(eq(x, y)) default {
@@ -2007,7 +2005,7 @@ Our intent is to replace all `tag_invoke` usages in [@P2300R5] by this proposal.
 
 We also cover other usage patterns of the standard library like `swap`, `std::begin`, `ranges::begin`, `std::get`, etc.
 
-However we have not investigated whether it would be possible to respecify the existing facilities in terms of language cpos without ABI breaks or subtle change of behaviour and we are not proposing to do that.
+However we have not investigated whether it would be possible to respecify the existing facilities in terms of language cpos without ABI breaks or subtle change of behaviour and we are not proposing to do that in this paper.
 
 Some facilities, like ranges for loops and structured bindings are currently specified in terms of raw ADL calls.
 

--- a/D2547.md
+++ b/D2547.md
@@ -1140,24 +1140,24 @@ Note that the declaration of a customisable function prototype is always a templ
 
 It is ill-formed to declare a normal function of the same name as a customisable function in the same namespace as the latter declares the name to be an object or variable template.
 
-## Customisable function CPO
+## Customisable function objects
 
-Each customisable function introduces a Customisation Point Object, which is a `constexpr` object of an implementation-defined trivial type with no data members.
+A customisable function declaration introduces a Customisation Function Object (CFO), which is a `constexpr` object of an unspecified, implementation-generated trivial type with no data members.
 
-A CPO exists as a way to name the customisable function.
+A CFO exists as a way to name the customisable function and can be copied and passed around as an object that represents the overload set of all implementations of this function.
 It allows the implementation of generic forwarders, and can more generally be used to pass an overload set generically.
 
-Neither default implementations or customisations are member functions of CPOs, and a CPO doesn't have call operators either.
-Instead, a call expression on a CPO triggers lookup and overload resolutions specific to customisable functions.
+Neither default implementations or customisations are member functions of CFOs, and a CFO doesn't have call operators either.
+Instead, a call expression on a CFO triggers lookup and overload resolutions specific to customisable functions.
 
 A CFO's type cannot be used as a base-class (similar to function-types).
-CPO types are default-constructible.
-All objects of a given CPO type are structurally identical and are usable as NTTPs.
-Members of CPO type are implicitly `[[no_unique_address]]`.
+CFO types are default-constructible.
+All objects of a given CFO type are structurally identical and are usable as NTTPs.
+Members of CFO type are implicitly `[[no_unique_address]]`.
 
 ## Declaring Customizations and Default Implementations
 
-Customisations and Default Implementations are implementations of Customisable functions.
+Customisations and Default Implementations are implementations of Customisable Functions.
 
 They form separate overload sets: only if overload resolution finds no suitable customisations do we look for a default implementation.
 
@@ -1443,7 +1443,7 @@ namespace std::execution
 }
 ```
 
-This ends up creating a single customisation point object named `std::execution::stop_when` that is callable with and that allows customisation of either of these signatures. i.e. that forms a single overload-set.
+This ends up creating a single customisation function object named `std::execution::stop_when` that is callable with and that allows customisation of either of these signatures. i.e. that forms a single overload-set.
 
 ## Customising customisable functions
 
@@ -1514,7 +1514,7 @@ This is intended to mimic the behaviour of normal template functions, such as `s
 
 Note that it is similarly valid for a customisable function template and a non-template customisable function of the same name to coexist beside each other as well, similar to normal functions.
 
-e.g. The following creates an object named `N::foo` and a variable template named `N::foo<T>`. These represent independent CPOs that can be customised separately.
+e.g. The following creates an object named `N::foo` and a variable template named `N::foo<T>`. These represent independent CFOs that can be customised separately.
 
 ```cpp
 namespace N {
@@ -1595,24 +1595,24 @@ struct array {
 
 # Generic forwarding
 
-When we are building wrapper types we want to be able to forward through a set of CPOs to the wrapped object.
+When we are building wrapper types we want to be able to forward through a set of customisable function calls on the wrapper to the wrapped object.
 
 Examples of such wrapper types include:
 
- - Type-erasing wrappers, where the list of CPOs to forward is specified via template parameters. e.g. `unifex::any_unique<cpo1, cpo2, cpo3>` where the generic type `any_unique` needs to be able to customise the arbitrary set of user-provided CPOs.
- - Types that customise one or more CPOs to have different behaviour and forward calls to other CPOs onto the wrapped value (if it supports them). This technique is used heavily in sender/receiver-based algorithm implementations (e.g. a receiver customising `get_allocator()` to return an allocator owned by the current operation, while forwarding other queries to the parent receiver).
+ - Type-erasing wrappers, where the list of customisable functions to forward is specified via template parameters. e.g. `unifex::any_unique<cfo1, cfo2, cfo3>` where the generic type `any_unique` needs to be able to customise the arbitrary set of user-provided CFOs.
+ - Types that customise one or more CFOs to have different behaviour and forward calls to other CFOs onto the wrapped value (if it supports them). This technique is used heavily in sender/receiver-based algorithm implementations (e.g. a receiver customising `get_allocator()` to return an allocator owned by the current operation, while forwarding other queries to the parent receiver).
 
-The ability to be able to generically customise different CPOs is built on the ability to define an override with a declarator-id that is deducible.
+The ability to be able to generically customise different CFOs is built on the ability to define an override with a declarator-id that is deducible.
 
 Example: A receiver type that customises the `get_allocator()` query and forwards other queries.
 
 ```cpp
-template<typename T, auto CPO, typename... Args>
+template<typename T, auto Signal, typename... Args>
 concept receiver_of =
   receiver<T> &&
-  completion_signal<CPO> &&
-  requires(CPO cpo, T&& r, Args&&... args) {
-    { cpo((T&&)r, (Args&&)args...) } noexcept;
+  completion_signal<Signal> &&
+  requires(T&& r, Args&&... args) {
+    { Signal((T&&)r, (Args&&)args...) } noexcept;
   };
 
 template<typename Receiver, typename Allocator>
@@ -1627,18 +1627,18 @@ struct allocator_receiver {
   }
 
   // Forward completion-signals
-  template<auto cpo, typename... Args>
-  requires receiver_of<allocator_receiver, CPO, Args...>
-  friend void cpo(allocator_receiver&& r, Args&&... args) noexcept override {
-    cpo(std::move(r.receiver), std::forward<Args>(args)...);
+  template<auto Signal, typename... Args>
+  requires receiver_of<Receiver, Signal, Args...>
+  friend void Signal(allocator_receiver&& r, Args&&... args) noexcept override {
+    Signal(std::move(r.receiver), std::forward<Args>(args)...);
   }
 
   // Forward query-like calls onto inner receiver
-  template<auto cpo>
-  requires (!completion_signal<CPO>) && std::invocable<decltype(cpo), const Receiver&>
-  friend decltype(auto) cpo(const allocator_receiver& r)
-      noexcept(std::is_nothrow_invocable<CPO, const Receiver&>) override {
-    return cpo(r.receiver);
+  template<auto Query>
+  requires (!completion_signal<Query>) && std::invocable<decltype(Query), const Receiver&>
+  friend decltype(auto) Query(const allocator_receiver& r)
+      noexcept(std::is_nothrow_invocable_v<Query, const Receiver&>) override {
+    return Query(r.receiver);
   }
 };
 ```
@@ -1744,7 +1744,7 @@ namespace mylib {
 
 If the customisable function prototype has a `noexcept(false)` specification or if the `noexcept` specification is absent then customisations and default implementations may either be declared as `noexcept(true)` or `noexcept(false)`. These rules are the same as for function pointer convertibility around `noexcept`.
 
-When a _noexcept-expression_ contains a _call-expression_ in its argument that resolves to a call to a customisable function, the result is evaluated based on the `noexcept`-specification of the selected overload of the customisable function rather than the `noexcept`-specification of the declaration of the customisable function.
+When a _noexcept-expression_ contains a _call-expression_ in its argument that resolves to a call to a customisable function, the result is evaluated based on the `noexcept`-specification of the selected overload of the customisable function rather than the `noexcept`-specification of the declaration of the customisable function prototype.
 
 ```cpp
 namespace std::ranges {
@@ -2070,7 +2070,7 @@ if (eq(a, b)) {
 
 :::
 
-We are able to express the same semantics in C++, although without some of the explicitness that we get from the Rust implementation of `PartialEq`. The C++ code that customises `eq()` does not make any reference to the `PartialEq` concept to indicate that we are customising a CPO associated with that trait.
+We are able to express the same semantics in C++, although without some of the explicitness that we get from the Rust implementation of `PartialEq`. The C++ code that customises `eq()` does not make any reference to the `PartialEq` concept to indicate that we are customising a function associated with that trait.
 
 The implementation on the C++ side is slightly more involved:
 
@@ -2086,7 +2086,7 @@ Our intent is to replace all `tag_invoke` usages in [@P2300R5] by this proposal.
 
 We also cover other usage patterns of the standard library like `swap`, `std::begin`, `ranges::begin`, `std::get`, etc.
 
-However we have not investigated whether it would be possible to respecify the existing facilities in terms of language cpos without ABI breaks or subtle change of behaviour and we are not proposing to do that in this paper.
+However we have not investigated whether it would be possible to respecify the existing facilities in terms of language customisable functions without ABI breaks or subtle change of behaviour and we are not proposing to do that in this paper.
 
 Some facilities, like ranges for loops and structured bindings are currently specified in terms of raw ADL calls.
 

--- a/D2547.md
+++ b/D2547.md
@@ -69,6 +69,12 @@ This paper introduces the following terms:
     They form the **customisation overload set**.
   - The set of functions or template functions with the `default` keyword are **default implementations** of the corresponding customisable function.
     They form the **default overload set** for that customisable function object.
+  - A declaration of a customisable function with explicit template parameters in the function declarator is a **customisable function template**.
+    e.g.
+    ```cpp
+	  template <typename T, typename Object>
+	  T* any_cast<T>(Object&& object) customisable;
+	```
   - A declaration of namespace-scope function of the form
 
     ```cpp
@@ -196,35 +202,11 @@ void example() {
 }
 ```
 
-## Generic customisations
-
-A type can customise a set of customisable-functions generically by defining namespace-scope **generic customisation**.
-
-```cpp
-template<typename Obj, typename Member>
-using member_t = decltype((std::declval<Obj>().*std::declval<Member Obj::*>()));
-
-template<typename Inner>
-struct logging_wrapper {
-  Inner inner;
-  // Forward calls with the first argument as 'logging_wrapper' to the inner object if callable
-  // on the inner object after printing out the name of the CPO that is being called.
-  template<@[auto cpo]{.hl}@, typename Self, typename... Args>
-    requires std::derived_from<std::remove_cvref_t<Self>, logging_wrapper> &&
-             std::invocable<decltype(cpo), member_t<Self, Inner>, Args...>
-  friend decltype(auto) @[cpo]{.hl}@(Self&& self, Args&&... args) noexcept(/* ... */) @[override]{.hl}@ {
-    std::print("Calling {}\n", typeid(cpo).name());
-    return @[cpo]{.hl}@(std::forward<Self>(self).inner, std::forward<Args>(args)...);
-  }
-};
-```
-
-A single `override` declaration is able to provide an overload for an open set of customisable functions by allowing the non-type template parameter `cpo` to be deduced to an instance of whichever customisation point object resolution is being performed for.
-
 ## Customizable function templates
 
-A customisable function template is declared with explicit template parameters.
-Calling the customisable function requires explicitly passing the template parameters and each specialisation of the customisable function results in an independent customisation point object.
+A customisable function template is declared as a customisable function where the function declarator has an explicit template parameter list.
+
+Calling the customisable function requires explicitly passing the template parameters and each specialisation of the customisable function results in a different customisation point object type.
 
 _Note:_ the ability to declare multiple variable templates of the same name but different parameter kinds is novel.
 
@@ -261,8 +243,33 @@ struct my_tuple {
 };
 ```
 
-_Note:_ unlike variables and variable templates, CFOs are not less-than-comparable, which means `cfo-name<token>` is unambiguously a template name and not a comparison.
+_Note:_ unlike variables and variable templates, CFOs are not less-than-comparable, which means `cfo-name<token>` can be unambiguously parsed as a template name and not a comparison, similar to function templates.
 This allows CFOs and CFO-templates to coexist in the same namespace.
+
+## Generic customisations
+
+A type can customise a set of customisable-functions generically by defining namespace-scope **generic customisation**.
+```cpp
+template<typename Obj, typename Member>
+using member_t = decltype((std::declval<Obj>().*std::declval<Member std::remove_cvref_t<Obj>::*>()));
+
+template<typename Inner>
+struct logging_wrapper {
+  Inner inner;
+
+  // Forward calls with the first argument as 'logging_wrapper' to the inner object if callable
+  // on the inner object after printing out the name of the CPO that is being called.
+  template<@[auto func]{.hl}@, typename Self, typename... Args>
+    requires std::derived_from<std::remove_cvref_t<Self>, logging_wrapper> &&
+             std::invocable<decltype(func), member_t<Self, Inner>, Args...>
+  friend decltype(auto) @[func]{.hl}@(Self&& self, Args&&... args) noexcept(/* ... */) @[override]{.hl}@ {
+    std::print("Calling {}\n", typeid(func).name());
+    return @[func]{.hl}@(std::forward<Self>(self).inner, std::forward<Args>(args)...);
+  }
+};
+```
+
+A single `override` declaration is able to provide an overload for an open set of customisable functions by allowing the non-type template parameter `func` to be deduced to an instance of whichever customisable function the compiler is currently performing overload resolution for.
 
 # Background
 

--- a/D2547.md
+++ b/D2547.md
@@ -21,7 +21,8 @@ This paper proposes a language mechanism for defining customisable namespace-sco
 
 # Status of this proposal
 
-This work is a preliminary initial design. We intend this proposal to replace the use of `tag_invoke` in [@P2300R4] in the C++26 time frame.
+This work is a preliminary initial design.
+We intend this proposal to replace the use of `tag_invoke` in [@P2300R5] in the C++26 time frame.
 We need directional guidance from EWG and LEWG to refine the design over the next few months.
 
 ## Revision 1
@@ -297,8 +298,8 @@ A discussion of [@P2279R0] in a joint library/language evolution session had str
 +====+====+===+====+====+
 | 30 | 12 | 2 | 0  | 0  |
 
-The paper [@P2300R4] _“`std::execution`”_ proposes a design that heavily uses customisable functions which are currently based on `tag_invoke` as the customisation mechanism.
-If [@P2300R4] is standardised with customisation points defined in terms of `tag_invoke()`, retrofitting them to support the language-based solution for customisable functions proposed in this paper will still carry all the downsides of `tag_invoke` due to backwards compatibility requirements.
+The paper [@P2300R5] _“`std::execution`”_ proposes a design that heavily uses customisable functions which are currently based on `tag_invoke` as the customisation mechanism.
+If [@P2300R5] is standardised with customisation points defined in terms of `tag_invoke()`, retrofitting them to support the language-based solution for customisable functions proposed in this paper will still carry all the downsides of `tag_invoke` due to backwards compatibility requirements.
 
 The added complexity of CPOs and abstractions to support both `tag_invoke` and a language solution may negate much of the benefit of using a language feature.
 
@@ -306,7 +307,7 @@ The committee should consider whether it is preferable to first standardise a la
 
 # Motivation
 
-A primary motivation for writing this paper was based on experience building libraries such as libunifex, which implement the sender/receiver concepts from [@P2300R4] and are heavily based on `tag_invoke` customisation point objects.
+A primary motivation for writing this paper was based on experience building libraries such as libunifex, which implement some earlier versions of sender/receiver concepts from [@P2300R5] and are heavily based on `tag_invoke` customisation point objects.
 
 While the `tag_invoke` mechanism for implementing customisation points is functional and powerful, there are a few things that make it less than ideal as the standard-blessed mechanism for customisable functions.
 
@@ -951,11 +952,11 @@ A customisable algorithm differs from a basis-function in that it has a default 
 
 ## Wrapper types
 
-One of the use-cases that needs to be supported for [@P2300R4]-style customisation points is the ability to generically customise many customisation points and forward them on to a wrapped object.
+One of the use-cases that needs to be supported for [@P2300R5]-style customisation points is the ability to generically customise many customisation points and forward them on to a wrapped object.
 
 This is used extensively in the definition of receiver types, which often need to customise an open set of queries about the calling context and forward them on to the parent receiver if the answer is not known locally.
 
-For example, a receiver defined using `tag_invoke` proposed by [@P2300R4] often looks like this:
+For example, a receiver defined using `tag_invoke` proposed by [@P2300R5] often looks like this:
 
 ```cpp
 template<typename T, typenname... Ts>
@@ -1282,7 +1283,7 @@ If the default were considered in overload resolution at the same time as custom
 
 By allowing implementations to be declared as defaults, and by defining overload resolution as a two-phase process - first try to find an overload marked as `override`, and only if no such overload was found try to find an overload marked `default` - we can ensure that customisations marked as `override` are preferred to default implementations, even if a default implementation would be a better match.
 
-Note that this approach closely matches the approach taken by `tag_invoke`-based CPOs defined in [P2300R4], which will generally check if there is a valid `tag_invoke()` overload that it can dispatch to, and only if there is no valid `tag_invoke()` overload, fall back to a default implementation.
+Note that this approach closely matches the approach taken by `tag_invoke`-based CPOs defined in [P2300R5], which will generally check if there is a valid `tag_invoke()` overload that it can dispatch to, and only if there is no valid `tag_invoke()` overload, fall back to a default implementation.
 
 ### Calling an override with argument conversion is preferred over calling a default
 
@@ -2001,8 +2002,8 @@ The implementation on the C++ side is slightly more involved:
 
 ## Redefining existing customisation points in terms of this solution
 
-Our intent is to replace all `tag_invoke` usages in [@P2300R4] by this proposal.
-([@P2300R4] makes extensive use of CPOs and forwarding)
+Our intent is to replace all `tag_invoke` usages in [@P2300R5] by this proposal.
+([@P2300R5] makes extensive use of CPOs and forwarding)
 
 We also cover other usage patterns of the standard library like `swap`, `std::begin`, `ranges::begin`, `std::get`, etc.
 

--- a/D2547.md
+++ b/D2547.md
@@ -1,5 +1,5 @@
 ---
-title: Language Support for customisable Functions
+title: Language Support for Customisable Functions
 document: D2547R1
 date: today
 audience: Evolution
@@ -39,23 +39,23 @@ We need directional guidance from EWG and LEWG to refine the design over the nex
 
 # Short description of the proposed facilities
 
-This proposal seeks to improve over existing customisation point mechanisms in a number of ways:
+This proposal seeks to improve over existing customisation-point mechanisms in a number of ways:
 
   - Allows customisation-point names to be namespace-scoped rather than names being reserved globally.
   - Allows generic forwarding of customisable functions through wrapper-types, including generic type-erasing wrappers (like `unifex::any_object`) and adapters that customise some operations and pass through others.
   - Concise syntax for defining customisable function-objects and adding customisations for particular types.
-  - Support for copy-elision of arguments passed by-value to customisation points.
+  - Support for copy-elision of arguments passed by-value to customisation-points.
   - Far better compile times compared to the `tag_invoke` mechanism (avoids 3 layers of template instantiations and cuts down on SFINAE required to separate implementation functions)
-  - Far better error messages compared to the `tag_invoke` mechanism (`tag_invoke` does not distinguish between different customisation point functions and sometimes results in reporting hundreds of unrelated overloads)
+  - Far better error messages compared to the `tag_invoke` mechanism (`tag_invoke` does not distinguish between different customisation-point functions and sometimes results in reporting hundreds of unrelated overloads)
 
-This proposal improves on the semantics of the `tag_invoke` proposal [@P1895R0], keeping namespace-scoped customisation points and generic customisation / forwarding, while providing a terser and cleaner syntax accessible to less experienced programmers.
+This proposal improves on the semantics of the `tag_invoke` proposal [@P1895R0], keeping namespace-scoped customisation-points and generic customisation / forwarding, while providing a terser and cleaner syntax accessible to less experienced programmers.
 
 The proposed syntax introduces use of:
 
   - A new _virt-specifier_ `customisable`{.cpp} for namespace-scope functions as a way of declaring that the function declaration is a customisation-point.
   - The _virt-specifier_ `override`{.cpp} for customisations of a customisable function-object.
   - The `default`{.cpp} keyword as an additional _virt-specifier_ annotation for a customisable function’s default implementation.
-  - The _virt-specifier_ `final`{.cpp} to create a non-customisable function object.
+  - The _virt-specifier_ `final`{.cpp} to create a non-customisable function-object.
   - A syntax for declaring customisations of a specific customisable function-object by using the fully-scoped name of the function-object as the function-name.
   - The ability to deduce the customisable function object for the purposes of generic forwarding and generically customising multiple customisation-points.
 
@@ -96,7 +96,7 @@ This paper introduces the following terms:
 ```cpp
 namespace std::execution {
   template<sender S, receiver R>
-  operation_state auto connect(S s, R r) customisable;
+  operation_state auto connect(S s, R r) @[customisable]{.hl}@;
 }
 ```
 
@@ -106,7 +106,7 @@ namespace std::execution {
 namespace std::ranges {
   template<input_range R, typename Value>
     requires equality_comparable_with<range_reference_t<R>, Value>
-  bool contains(R&& range, const Value& v) customisable;
+  bool contains(R range, Value v) customisable;
 
   template<input_range R, typename Value>
     requires equality_comparable_with<range_reference_t<R>, Value>
@@ -1177,7 +1177,7 @@ We can declare zero or more default implementations or implementation templates 
 Default implementations are only considered during overload resolution if no viable customisation of the function is found.
 
 Default implementations are overloads of the customisable function that are declared with the `default` keyword.
-The keyword is placed in the same syntactic location as `customisable`, ie where the `override` and `final` keywords are placed for member functions. after the `noexcept` and any trailing return type.
+The keyword is placed in the same syntactic location as `customisable`, ie where the `override` and `final` keywords are placed for member functions, after the `noexcept` and any trailing return type.
 
 A default implementation is declared as a separate declaration after the prototype.
 This is because the `noexcept` clause, constraints and return type of default (and overrides) functions are not handled the same way as in the prototypes declaration, and keeping them separate keeps the design simpler.
@@ -1195,7 +1195,7 @@ namespace std::ranges {
   bool contains(R&& range, const V& value) default {
     for (auto&& x : range) {
       if (x == value)
-          return true;
+        return true;
     }
     return false;
   }
@@ -1950,29 +1950,19 @@ R some_getter(const T& x) customisable;
 
 ## Syntax
 
-This version of the proposal introduces the `customisable` contextual keyword,
-and uses `customisable`, `default`, `override` and `final` all as trailing keywords
-in function declarations.
+This version of the proposal uses the `customisable` contextual keyword, and uses `customisable`, `default`, `override` and `final` all as trailing keywords in function declarations.
 The syntax is of course subject to change.
 
-R0 of the proposal used the `virtual` keyword, on non-member functions,
-as an argument could be made that what we proposes is, in some way,
-a form of static polymorphism.
+R0 of the proposal used the `virtual` keyword, on non-member functions, as an argument could be made that what we proposes is, in some way, a form of static polymorphism.
 
-However, it is clear from the initial reactions, that most people associate `virtual`
-with inheritence and dynamic polymorphism.
-As this proposal is definitively not that (it is a compile-time mechanism
-which does not impact runtime performance), R1 introduced a different syntax.
+However, it is clear from the initial reactions, that most people associate `virtual` with inheritence and dynamic polymorphism.
+As this proposal is definitively not that (it is a compile-time mechanism which does not impact runtime performance), R1 introduced a different syntax.
 
-Some additional concerns were raised that `virtual` may also be used by multimethods,
-should such a proposal ever be made and be accepted.
-We note in languages with a similar feature, the syntactic marker is usually on
-parameters rather than on the function itself, and so there would
-not be an issue in terms of keeping the design space open.
+Some additional concerns were raised that `virtual` may also be used by multimethods, should such a proposal ever be made and be accepted.
+We note in languages with a similar feature, the syntactic marker is usually on parameters rather than on the function itself, and so there would not be an issue in terms of keeping the design space open.
 
-In general, we agree that there were enough arguments against `virtual` to
-warrant a different syntax. We realized a syntax not associated with dynamic
-polymorphism would be better perceived and more easily learned by C++ users.
+In general, we agree that there were enough arguments against `virtual` to warrant a different syntax.
+We realized a syntax not associated with dynamic polymorphism would be better perceived and more easily learned by C++ users.
 
 We welcome suggestions to further improve the syntax.
 

--- a/D2547.md
+++ b/D2547.md
@@ -24,6 +24,11 @@ This paper proposes a language mechanism for defining customisable namespace-sco
 This work is a preliminary initial design. We intend this proposal to replace the use of `tag_invoke` in [@P2300R4] in the C++26 time frame.
 We need directional guidance from EWG and LEWG to refine the design over the next few months.
 
+## Revision 1
+  - New syntax to introduce customisable functions, using a contextual keyword (`customisable`)
+  rather than `virtual`. This is to address initial feedback that re-using `virtual` for a feature
+  unrelated to dynamic polymorphism was, at best, confusing.
+
 # Short description of the proposed facilities
 
 This proposal seeks to improve over existing customisation point mechanisms in a number of ways:
@@ -39,11 +44,11 @@ This proposal improves on the semantics of the `tag_invoke` proposal [@P1895R0],
 
 The proposed syntax introduces use of:
 
-  - The `virtual`{.cpp} function-specifier for namespace-scope functions as a way of declaring that the function is a customisation-point (syntax idea borrowed from [@P1292R0] “customisation Point Functions”).
+  - A new _virt-specifier_ `customisable`{.cpp} for namespace-scope functions as a way of declaring that the function declaration is a customisation-point.
   - The _virt-specifier_ `override`{.cpp} for customisations of a customisable function-object.
-  - The _pure-specifier_ `= 0` for declaring a customisable function without a default implementation
   - The `default`{.cpp} keyword as an additional _virt-specifier_ annotation for a customisable function’s default implementation.
-  - A syntax for declaring customisations of a specific customisable function-object by using the fully-scoped name of the function-object as the function-name.
+  - The _virt-specifier_ `final`{.cpp} to create a non-customisable function object.
+  - A syntax for declaring customisations of a specific customisable function-object by using the  fully-scoped name of the function-object as the function-name.
   - The ability to deduce the customisable function object for the purposes of generic forwarding.
 
 # Terminology
@@ -53,7 +58,7 @@ This paper introduces the following terms:
   - A function declaration for a _customisable function_ is a **customisable function prototype**:
 
     ```cpp
-      virtual void foo(auto&&) = 0;
+      void foo(auto&&) customisable;
     ```
 
   - The set of _customisable function prototypes_ naming the same entity represent a **customisable function**.
@@ -74,12 +79,10 @@ This paper introduces the following terms:
 
 ## Declaring a customisable function
 
-The trailing `= 0` indicates this is a declaration without a default implementation.
-
 ```cpp
 namespace std::execution {
   template<sender S, receiver R>
-  virtual operation_state auto connect(S s, R r) @[=]{.hl} [0]{.hl}@;
+  operation_state auto connect(S s, R r) customisable;
 }
 ```
 
@@ -89,7 +92,11 @@ namespace std::execution {
 namespace std::ranges {
   template<input_range R, typename Value>
     requires equality_comparable_with<range_reference_t<R>, Value>
-  @[virtual]{.hl}@ bool contains(R&& range, const Value& v) @[default]{.hl}@ {
+    bool contains(R&& range, const Value& v) customisable;
+
+  template<input_range R, typename Value>
+    requires equality_comparable_with<range_reference_t<R>, Value>
+    bool contains(R&& range, const Value& v) default {
     for (const auto& x : range) {
       if (x == v) return true;
     }
@@ -176,7 +183,7 @@ This object represents the overload set of all overloads of that function, and s
 
 ```cpp
 template<typename T>
-virtual void frobnicate(T& x) = 0;
+void frobnicate(T& x) customisable;
 
 struct X {
   friend void frobnicate(X& x) override { ... }
@@ -223,15 +230,18 @@ _Note:_ the ability to declare multiple variable templates of the same name but 
 namespace std {
   // get for types
   template<typename T, typename Obj>
-  virtual auto @[get<T>]{.hl}@(Obj&& obj) = 0;
+  auto @[get<T>]{.hl}@(Obj&& obj) customisable;
 
   // get for numeric indices
   template<size_t N, typename Obj>
-  virtual auto @[get<N>]{.hl}@(Obj&& obj) = 0;
+  auto @[get<N>]{.hl}@(Obj&& obj) customisable;
 
   // get that deduces numeric indices, no template args
   template<size_t N, typename Obj>
-  virtual auto @[get]{.hl}@(Obj&& obj, std::integral_constant<size_t, N>) default
+  auto @[get]{.hl}@(Obj&& obj, std::integral_constant<size_t, N>) customisable;
+
+  template<size_t N, typename Obj>
+  auto @[get]{.hl}@(Obj&& obj, std::integral_constant<size_t, N>) default
     -> decltype(auto) {
        return std::get<N>(std::forward<Obj>(obj);
   }
@@ -353,15 +363,18 @@ inline constexpr contains_t contains{};
 namespace std::ranges {
 
 template<input_range R, typename Value>
-  requires
-    equality_comparable_with<range_reference_t<R>, Value>
-virtual bool contains(R&& range, const Value& v) default
-{
+  requires equality_comparable_with<range_reference_t<R>, Value>
+bool contains(R&& range, const Value& v) customisable;
+
+template<input_range R, typename Value>
+  requires equality_comparable_with<range_reference_t<R>, Value>
+bool contains(R&& range, const Value& v) default {
   for (const auto& x : range) {
     if (x == v) return true;
   }
   return false;
 }
+
 
 } // namespace std::ranges
 ```
@@ -421,7 +434,7 @@ namespace GUI {
 
 namespace CONTAINER {
   template<typename T>
-  concept sized_container = 
+  concept sized_container =
     requires (const T& c) {
       { c.size() } -> std::same_as<typename T::size_type>;
     };
@@ -484,7 +497,7 @@ struct foo_a : foo_base {};
 
 struct foo_b : foo_base {
   void thing1() { std::print("foo_b thing1\n"); }
-};  
+};
 ```
 
 We can then later extend `foo_base` to add additional members with default implementations in a non-breaking fashion.
@@ -674,7 +687,7 @@ This problem does not usually come up when using the two-step `using`, however, 
 
 The `std::ranges` library defines a number of customisation point objects which build on ADL, but that make the customization points easier to use correctly by encapsulating the two-step using approach in the call operator of the CPO.
 
-For example: A rough approximation of the `std::ranges::swap()` CPO defined 
+For example: A rough approximation of the `std::ranges::swap()` CPO defined
 
 ```cpp
 namespace std::ranges {
@@ -894,7 +907,7 @@ Overload set sizes can be reduced somewhat by careful use of hidden-friend defin
 
 Specifically, **the overload set size grows with the _product_ of _cpo-count_ and _argument count_ **, and that is _if_ one studiously follows hidden-friend cleanliness; if one does not, the size also grows with the number of all specializations in all associated namespaces.
 
-Note that raw ADL does not usually have the same problem as different names are typically used for each customisation point and so overload resolution only needs to consider functions with the same name as the function currently being called and can ignore overloads for other customisation-points, thus removing an entire growth factor.
+Note that raw ADL does not usually have the same problem as different names are typically used for each customisation point and so overload resolution only needs to consider functions with the same name as the function currently being called and can ignore overloads for other customisation points, thus removing an entire growth factor.
 
 ### Forwarding layers inhibit copy-elision
 
@@ -990,9 +1003,9 @@ Another use-case for building generic forwarding wrappers types is building gene
 For example, the `libunifex::any_unique<CPOs…>` type defines a type-erasing wrapper that can generically type-erase any type that satisfies the set of CPOs.
 
 ```cpp
-virtual float width(const T& x) = 0;   // this paper, or as-if tag_invoke CPO
-virtual float height(const T& x) = 0;
-virtual float area(const T& x) = 0;
+float width(const T& x) customisable;   // this paper, or as-if tag_invoke CPO
+float height(const T& x) customisable;
+float area(const T& x) customisable;
 
 template<typename T>
 concept shape = requires(const T& x) {
@@ -1026,23 +1039,19 @@ Other type-erasing wrapper types are possible that make different choices on sto
 
 # Design
 
-A **customisable function prototype** is a namespace-scope function declaration prefixed with the `virtual` keyword.
+A **customisable function prototype** is a namespace-scope function declaration with the `customisable` _virt-specifier_.
 
 Calls to customisable functions dispatch to the appropriate customisation or default implementation based on the static types of the arguments to that call.
 
 ## Declaring customisable functions
 
-A namespace-scope function declarator declares a customisable function prototype if the declaration contains the `virtual` keyword in its function-specifier.
-
-A declaration of a _customisable function prototype_ that has no default (i.e. a basis operation) is introduced with the `virtual` keyword, indicating a customisable function prototype, and an `= 0;`, indicating that there is no default defined inline.
-
-For example, you can declare a `hash()` customisable function prototype that may be used by hash-table implementations in a container library but where there is no generic default implementation possible.
+A namespace-scope function declarator declares a customisable function prototype if the declaration contains the `customisable` keyword in its function-specifier.
+The keyword is placed in the same syntactic location of the function definition that the `override` and `final` keywords are placed for member functions. i.e. after the `noexcept` and any trailing return type.
 
 ```cpp
-namespace containers
-{
+namespace containers {
   template<typename T, std::unsigned_integral InitialValue>
-  virtual InitialValue hash(const T& value, InitialValue iv) noexcept = 0;
+  InitialValue hash(const T& value, InitialValue iv) noexcept customisable;
 }
 ```
 
@@ -1081,40 +1090,25 @@ We can declare zero or more default implementations or implementation templates 
 Default implementations are only considered during overload resolution if no viable customisation of the function is found.
 
 Default implementations are overloads of the customisable function that are declared with the `default` keyword.
-The keyword is placed in the same syntactic location of the function definition that the `override` and `final` keywords are placed for member functions. i.e. after the `noexcept` and any trailing return type.
+The keyword is placed in the same syntactic location as `customisable`, ie where the `override` and `final` keywords are placed for member functions. after the `noexcept` and any trailing return type.
 
-A default implementation can either be defined inline with the declaration or can be defined later as a separate `default` declaration.
+A default implementation is declared as a separate declaration after the prototype.
+This is because the `noexcept` clause, constraints and return type of default (and overrides) functions are not handled the same way as in the prototypes declaration, and keeping them separate keeps the design simpler.
 
-For example: Declaring a hypothetical customisable `std::ranges::contains()` algorithm with a default implementation provided at the point of declaration.
+Example: Declaring a hypothetical customisable `std::ranges::contains()` algorithm with a default implementation provided at the point of declaration.
 
 ```cpp
 namespace std::ranges {
   template<input_range R, typename V>
   requires equality_comparable_with<range_reference_t<R>, const V&>
-  virtual bool contains(R&& range, const V& value) default {
-    for (auto&& x : range) {
-      if (x == value) 
-          return true;
-    }
-    return false;
-  }
-}
-```
-
-This definition is semantically equivalent to a separate declaration of the customisable function and a declaration with inline definition of the default implementation. i.e. is equivalent to the following:
-
-```cpp
-namespace std::ranges
-{
-  template<input_range R, typename V>
-  requires equality_comparable_with<range_reference_t<R>, const V&>
-  virtual bool contains(R&& range, const V& value) = 0;
+  bool contains(R&& range, const V& value) customisable;
 
   template<input_range R, typename V>
   requires equality_comparable_with<range_reference_t<R>, const V&>
   bool contains(R&& range, const V& value) default {
     for (auto&& x : range) {
-      if (x == value) return true;
+      if (x == value)
+          return true;
     }
     return false;
   }
@@ -1129,7 +1123,7 @@ namespace std::ranges {
   // Declaration of customisable function.
   template<input_range R, typename V>
   requires equality_comparable_with<range_reference_t<R>, const V&>
-  virtual bool contains(R&& range, const V& value) = 0;
+  bool contains(R&& range, const V& value) customisable;
 
   // Forward declaration of default implementation.
   template<input_range R, typename V>
@@ -1152,18 +1146,15 @@ namespace std::ranges {
 }
 ```
 
-Default implementations should be declared separately from the customisable function prototype in cases where we don’t want to constrain all customisations to have the same return type or `noexcept` specification as the default implementation, even though the default implementation has the same constraints on its parameters as the customisable function prototype and so is valid for all arguments that would be valid for the customisable function prototype.
-
-For example, if we wanted to make a customisable sender algorithm, customisations might only be required to return some type that satisfies the sender concept, whereas the default implementation will need to return a particular sender-type (something that we wouldn’t want all customisations to have to return).
-
-In this case we need to declare the customisation point with general constraints on the return type but with a pure virtual descriptor, and define a separate default implementation that returns a particular concrete type that satisfies those constraints. e.g.
+If we wanted to make a customisable sender algorithm, customisations might only be required to return some type that satisfies the sender concept, whereas the default implementation will need to return a particular sender-type (something that we wouldn’t want all customisations to have to return).
+In this case we need to declare the customisation point with general constraints on the return type, and define a default implementation that returns a particular concrete type that satisfies those constraints. e.g.
 
 ```cpp
 namespace std::execution {
   // Declaration of customisation-point defines only general constraints.
   template<sender S, typename F>
   requires invocable-with-sender-value-results<F, S>
-  sender auto then(S&& src, F&& func) = 0;
+  sender auto then(S&& src, F&& func) customisable;
 
   // Class used by default implementation. Satisfies 'sender' concept.
   template<sender S, typename F>
@@ -1179,14 +1170,14 @@ namespace std::execution {
 }
 ```
 
-We can also declare a customisable function with default implementations that are only valid for types that satisfy some additional constraints by declaring the customisable function first with the `= 0;` and then declaring additional overloads with the `default` keyword.
+We can also declare a customisable function with default implementations that are only valid for types that satisfy some additional constraints.
 
 For example: Declaring the `swap()` customisable function (which permits swapping between any two types) but only providing a default that works with types that are move-constructible/move-assignable.
 
 ```cpp
 namespace std::ranges {
   template<typename T, typename U>
-  virtual void swap(T&& t, U&& u) = 0;
+  void swap(T&& t, U&& u) customisable;
 
   template<typename V>
   requires std::move_constructible<V> && std::assignable_from<V&, V&&>
@@ -1231,12 +1222,12 @@ e.g.
 ```cpp
 namespace containers {
   template<typename T, std::unsigned_integral IV>
-  virtual IV hash(const T& value, IV iv) noexcept = 0;
+  IV hash(const T& value, IV iv) noexcept customisable;
 }
 namespace otherlib {
   // Hash function used for types in this library
   template<typename T>
-  virtual std::unsigned_integral hash(const T& value) noexcept = 0;
+  std::unsigned_integral hash(const T& value) noexcept;
   template<typename T>
   concept hashable = requires(const T& value) { hash(value); };
 
@@ -1301,7 +1292,7 @@ For example, consider:
 
 ```cpp
 template<typename T, typename U>
-virtual void swap(T&& t, U&& u) = 0;
+void swap(T&& t, U&& u) customisable;
 
 template<typename T>
 requires std::move_constructible<T> && std::assignable_from<T&, T&&>
@@ -1351,7 +1342,7 @@ It could be made consistent in this case by explicitly defining an overload of `
 Sometimes we would like to use a given name for multiple forms of a customisable function.
 For example, to add overloads that take different numbers of arguments, or that take arguments of different types or concepts.
 
-It is possible to declare multiple customisation point overloads with the same name by declaring multiple ‘virtual’ functions with the same name in the same namespace.
+It is possible to declare multiple customisation point overloads with the same name by declaring multiple `customisable` functions with the same name in the same namespace.
 
 For example, we might want to define two flavours of the sender algorithm `stop_when()`.
 
@@ -1362,12 +1353,12 @@ namespace std::execution
   // Requests cancellation of the other operation when one completes.
   // Completes with result of 'source' once both operations have completed.
   template<sender Source, sender Trigger>
-  virtual sender auto stop_when(Source source, Trigger trigger) default;
+  sender auto stop_when(Source source, Trigger trigger) customisable;
 
   // Create a sender that sends a stop-request to 'source' if a stop-request
   // is delivered on the input stop-token.
   template<sender Source, stoppable_token ST>
-  virtual sender auto stop_when(Source source, ST stop_token) default;
+  sender auto stop_when(Source source, ST stop_token) customisable;
 }
 ```
 
@@ -1383,7 +1374,7 @@ For example: Given the following customisation point declaration
 ```cpp
 namespace shapes {
   template<typename T>
-  virtual float area(const T& shape) noexcept = 0;
+  float area(const T& shape) noexcept customisable;
 }
 ```
 
@@ -1428,11 +1419,11 @@ namespace std {
                            std::same_as<std::remove_cvref_t<T>, U>;
   // Get the element of 'obj' with type T
   template<typename T, typename Obj>
-  virtual reference_to<T> auto get<T>(Obj&& obj) = 0;
+  reference_to<T> auto get<T>(Obj&& obj) customisable;
 
   // Get the Nth element of 'obj'
   template<size_t N, typename Obj>
-  virtual auto&& get<N>(Obj&& obj) = 0;
+  auto&& get<N>(Obj&& obj) customisable;
 }
 ```
 
@@ -1446,10 +1437,10 @@ e.g. The following creates an object named `N::foo` and a variable template name
 
 ```cpp
 namespace N {
-  virtual void foo(auto& obj, const auto& value) = 0;
+  void foo(auto& obj, const auto& value) customisable;
 
   template<typename T>
-  virtual void foo<T>(auto& obj, const T& value) = 0;
+  void foo<T>(auto& obj, const T& value) customisable;
 }
 
 struct X {
@@ -1500,7 +1491,7 @@ struct pair {
   requires (!std::same_as<First, Second>) override {
     return self.first;
   }
-  
+
   friend Second& std::get<Second>(pair& self) noexcept
   requires (!std::same_as<First, Second>) override {
     return self.second;
@@ -1608,7 +1599,7 @@ For example, if I declare the following customisable function:
 
 ```cpp
 template<typename Obj>
-virtual void resize(Obj& obj, size_t size) = 0;
+void resize(Obj& obj, size_t size) customisable;
 ```
 
 And if I had a type, say:
@@ -1639,7 +1630,7 @@ This is done by attempting to match the signature of the selected overload to th
      - If the `noexcept`-specifier evaluates to `noexcept(true)` then if the implementation does not have a `noexcept(true)` specifier, the program is ill-formed.
    - If the `consteval`-ness of the prototype does not match the `consteval`-ness of the selected overload, discard the prototype.
  - If there were no customisable function prototypes that were not discarded for which the overload was able to successfully match then the program is ill-formed. [[Note: Because the implementation was an invalid overload]].
- 
+
 Parts of this process are described in more detail [Noexcept specifications](#noexcept-specifications), [Constraining parameter-types](#constraining-parameter-types) and [Constraining return types](#constraining-return types).
 
 ### Noexcept specifications
@@ -1651,7 +1642,7 @@ If the customisable function prototype has a `noexcept(true)` specification then
 ```cpp
 namespace somelib {
   template<typename T>
-  virtual void customisable_func(const T& x) noexcept = 0;
+  void customisable_func(const T& x) noexcept customisable;
 }
 
 namespace mylib {
@@ -1677,7 +1668,7 @@ When a _noexcept-expression_ contains a _call-expression_ in its argument that r
 ```cpp
 namespace std::ranges {
   template<typename T, typename U>
-  virtual void swap(T&& t, U&& u) = 0;
+  void swap(T&& t, U&& u) customisable;
 }
 
 struct type_a {
@@ -1699,8 +1690,8 @@ For example: Consider a hypothetical `make_stop_callback()` inspired from [@P217
 ```cpp
 template<stoppable_token ST, typename F>
   requires std::invocable<std::decay_t<F>>
-virtual auto make_stop_callback(ST st, F func)
-  noexcept(std::is_nothrow_constructible_v<std::decay_t<F>, F>) = 0;
+auto make_stop_callback(ST st, F func)
+  noexcept(std::is_nothrow_constructible_v<std::decay_t<F>, F>) customisable;
 
 struct never_stop_token { ... };
 struct never_stop_callback {};
@@ -1739,7 +1730,7 @@ Given:
 ```cpp
 template<std::ranges::range R,
          std::equality_comparable_with<std::ranges::range_reference_t<R>> V>
-virtual bool contains(R range, V value) = 0;
+bool contains(R range, V value) customisable;
 
 template<std::ranges::range R, typename V>
   requires std::equality_comparable_with<
@@ -1787,21 +1778,21 @@ template<typename T>
 concept prvalue = (!std::is_reference_v<T>);
 
 // Force customisations to accept parameters by-value
-virtual auto combine(prvalue auto first, prvalue auto second) = 0;
+auto combine(prvalue auto first, prvalue auto second) customisable;
 ```
 
 It is also important to note that we can constrain the signature of the selected overload to have particular concrete parameter types, or to have a parameter that is a specialization of a particular template. e.g.
 
 ```cpp
 template<typename Shape>
-virtual Shape scale(Shape s, float factor) = 0; // 'factor' param must be
+Shape scale(Shape s, float factor) customisable; // 'factor' param must be
                                                 // 'float' to match signature.
 
 // The 'request' parameter can be constrained to be a shared_ptr of some
 // type that satisfies the 'httplib::request' concept.
 template<typename Processor, httplib::request Request>
-virtual void process_request(Processor& p,
-                             std::shared_ptr<Request> request) = 0;
+void process_request(Processor& p,
+                             std::shared_ptr<Request> request) customisable;
 ```
 
 ### Constraining return types
@@ -1817,7 +1808,7 @@ For example, the `std::ranges::begin()` customisation point might be defined as 
 ```cpp
 namespace std::ranges {
   template<typename R>
-  virtual input_or_output_iterator auto begin(R range) = 0;
+  input_or_output_iterator auto begin(R range) customisable;
 
   template<typename T, std::size_t N>
   T* begin(T(&range)[N]) noexcept override {
@@ -1841,7 +1832,7 @@ namespace std::ranges
 {
   template<typename R, typename It>
     requires input_or_output_iterator<It>
-  virtual It begin(R range) = 0;
+  It begin(R range) customisable;
 }
 ```
 
@@ -1853,10 +1844,38 @@ This more explicit syntax can be used to apply multiple constraints to the retur
 ```cpp
 template<typename R, typename T>
 requires decay_copyable<R> && some_concept<std::decay_t<R>>
-virtual R some_getter(const T& x) = 0;
+R some_getter(const T& x) customisable;
 ```
 
 # Additional Design Discussions
+
+## Syntax
+
+This version of the proposal introduces the `customisable` contextual keyword,
+and uses `customisable`, `default`, `override` and `final` all as trailing keywords
+in function declarations.
+The syntax is of course subject to change.
+
+R0 of the proposal used the `virtual` keyword, on non-member functions,
+as an argument could be made that what we proposes is, in some way,
+a form of static polymorphism.
+
+However, it is clear from the initial reactions, that most people associate `virtual`
+with inheritence and dynamic polymorphism.
+As this proposal is definitively not that(It is a compile0time mechanism
+which does not impact runtime performance), R1 introduce a different syntax.
+
+Some additional concerns were raised that `virtual` may also be used by multimethods,
+should such a proposal ever be made and be accepted.
+We note in languages with a similar feature, the syntactic marker is usually on
+parameters rather than on the function itself, and so there would
+not be an issue in terms of keeping the design space open.
+
+In general, we agree that there were enough arguments against `virtual` to
+warrant a different syntaxe. We realized a syntax not associated with dynamic
+polymorphism would be better perceived and more easily learned by C++ users.
+
+We welcome suggestions to further improve the syntax.
 
 ## Default arguments
 
@@ -1890,7 +1909,7 @@ This is an example from Barry Revzin’s blog post on customisation points [@Rev
 ```rust
 trait PartialEq {
     fn eq(&self, rhs: &Self) -> bool;
-    
+
     fn ne(&self, rhs: &Self) -> bool {
         !self.eq(rhs)
     }
@@ -1900,14 +1919,16 @@ trait PartialEq {
 ### This proposal
 ```cpp
 template<typename T>
-virtual bool eq(const T& x, const T& y) = 0;
+bool eq(const T& x, const T& y) customisable;
 
 template<typename T>
 requires requires(const T& x, const T& y) {
     eq(x, y);
 }
-virtual bool ne(const T& x, const T& y)
-    noexcept(eq(x, y)) default {
+
+bool ne(const T& x, const T& y) customisable;
+
+bool ne(const T& x, const T& y) noexcept(eq(x, y)) default {
   return !eq(x, y);
 };
 

--- a/D2547.md
+++ b/D2547.md
@@ -100,11 +100,11 @@ namespace std::execution {
 namespace std::ranges {
   template<input_range R, typename Value>
     requires equality_comparable_with<range_reference_t<R>, Value>
-    bool contains(R&& range, const Value& v) customisable;
+  bool contains(R&& range, const Value& v) customisable;
 
   template<input_range R, typename Value>
     requires equality_comparable_with<range_reference_t<R>, Value>
-    bool contains(R&& range, const Value& v) default {
+  bool contains(R&& range, const Value& v) default {
     for (const auto& x : range) {
       if (x == v) return true;
     }
@@ -145,9 +145,9 @@ namespace std {
 
   // Defined outside class definition.
   template<class Key, class Hash, class Eq, class Allocator, class Value>
-  requires(const unordered_set<Key,Hash,Eq, Allocator>& s, const Value& v) {
+    requires(const unordered_set<Key,Hash,Eq, Allocator>& s, const Value& v) {
       s.contains(v);
-  }
+    }
   bool @[ranges::contains]{.hl}@(const unordered_set<Key,Hash,Eq,Allocator>& s,
                         const Value& v) @[override]{.hl}@ {
     return s.contains(v);
@@ -1879,13 +1879,13 @@ It is also important to note that we can constrain the signature of the selected
 ```cpp
 template<typename Shape>
 Shape scale(Shape s, float factor) customisable; // 'factor' param must be
-                                                // 'float' to match signature.
+                                                 // 'float' to match signature.
 
 // The 'request' parameter can be constrained to be a shared_ptr of some
 // type that satisfies the 'httplib::request' concept.
 template<typename Processor, httplib::request Request>
 void process_request(Processor& p,
-                             std::shared_ptr<Request> request) customisable;
+                     std::shared_ptr<Request> request) customisable;
 ```
 
 ### Constraining return types
@@ -2016,7 +2016,7 @@ bool eq(const T& x, const T& y) customisable;
 
 template<typename T>
 requires requires(const T& x, const T& y) {
-    eq(x, y);
+  eq(x, y);
 }
 bool ne(const T& x, const T& y) customisable;
 
@@ -2086,8 +2086,8 @@ We are able to express the same semantics in C++, although without some of the e
 
 The implementation on the C++ side is slightly more involved:
 
- - The default implementation of `ne()` is constrained to only be valid if there is an `eq()`.
-   We could also consider putting this requirement on the `ne()` declaration instead of just on the default implementation if we always wanted people to provide an `eq()` if they provide a `ne()`.
+ - The declaration of the `ne()` prototype requires that `eq()` is valid.
+   This means you can't accidentally customise `ne()` and not define `eq()`.
  - The default implementation of `ne()` deals with forwarding `noexcept`-ness
 
 

--- a/D2547.md
+++ b/D2547.md
@@ -1150,7 +1150,7 @@ It allows the implementation of generic forwarders, and can more generally be us
 Neither default implementations or customisations are member functions of CPOs, and a CPO doesn't have call operators either.
 Instead, a call expression on a CPO triggers lookup and overload resolutions specific to customisable functions.
 
-It should be possible to inherit from CPO types.
+A CFO's type cannot be used as a base-class (similar to function-types).
 CPO types are default-constructible.
 All objects of a given CPO type are structurally identical and are usable as NTTPs.
 Members of CPO type are implicitly `[[no_unique_address]]`.

--- a/D2547.md
+++ b/D2547.md
@@ -142,7 +142,7 @@ namespace std {
   requires(const unordered_set<Key,Hash,Eq, Allocator>& s, const Value& v) {
       s.contains(v);
   }
-  bool @[ranges::contains]{.hl}@(const unordered_set<K,H,Eq,A>& s,
+  bool @[ranges::contains]{.hl}@(const unordered_set<Key,Hash,Eq,Allocator>& s,
                         const Value& v) @[override]{.hl}@ {
     return s.contains(v);
   }

--- a/D2547.md
+++ b/D2547.md
@@ -1965,7 +1965,7 @@ parameters rather than on the function itself, and so there would
 not be an issue in terms of keeping the design space open.
 
 In general, we agree that there were enough arguments against `virtual` to
-warrant a different syntaxe. We realized a syntax not associated with dynamic
+warrant a different syntax. We realized a syntax not associated with dynamic
 polymorphism would be better perceived and more easily learned by C++ users.
 
 We welcome suggestions to further improve the syntax.

--- a/D2547.md
+++ b/D2547.md
@@ -1064,7 +1064,7 @@ struct my_receiver {
   }
 
   friend void tag_invoke(tag_t<std::execution::set_done>, my_receiver&& r) noexcept {
-    std::execution::set_done(std::move(r));
+    std::execution::set_done(std::move(r.op->receiver));
   }
 
   // Generically forward through any receiver query supported upstream.


### PR DESCRIPTION
`void foo(auto) customisable;`

to get rid of virtual.

Make the default declaration always separate from the declaration
of a customisable function.